### PR TITLE
Тест к #3

### DIFF
--- a/source/bigtest.d
+++ b/source/bigtest.d
@@ -92,4 +92,13 @@ unittest
 {
 	immutable testFile = "test/test1/test.xml";
 	auto a = parseAll([testFile]);
+	assert(a.length == 1);
+}
+
+
+unittest
+{
+	immutable testFile = "test/test2/test.xml";
+	auto a = parseAll([testFile]);
+	assert(a.length == 1);
 }

--- a/test/test2/test.xml
+++ b/test/test2/test.xml
@@ -1,0 +1,11 @@
+<app1 name="app1">
+	<input>
+		<!-- Input -->
+		<signal name="name2"/>
+	</input>
+
+	<output>
+		<!-- Output -->
+		<signal name="name1"/>
+	</output>
+</app1>


### PR DESCRIPTION
Текущий способ пропуска двойного тире в комментариях ломает парсинг корректных файлов